### PR TITLE
add fastBundle testnet builder

### DIFF
--- a/testnet/builders/fastbundle-builder.toml
+++ b/testnet/builders/fastbundle-builder.toml
@@ -1,0 +1,7 @@
+Address = "0xf9e5140b638c4238e8020c6bc08d5c4092f8b8b5"
+RPC = "https://testnet.fastbundle.io"
+Website = "https://fastbundle.io"
+Contact = "support@fastbundle.com"
+EVNNodeIDs = [
+    "698c9c564def4173d86328fbcf1feee0c90c803bb9a09e7221cd12bfc85fbb8d",
+]


### PR DESCRIPTION
## Summary
Add FastBundle.io as a new builder to the BSC testnet.

## Builder Information
- **Name**: FastBundle.io
- **Network**: BSC Testnet
- **RPC Endpoint**: https://testnet.fastbundle.io
- **Builder Address**: 0xf9e5140b638c4238e8020c6bc08d5c4092f8b8b5

## Description
FastBundle.io is a neutral block builder providing professional MEV optimization solutions for the BSC network. We run multiple bundle merging algorithms in parallel through our proprietary high-performance infrastructure.

## Contact
For any questions or technical support, please reach out through our official channels.